### PR TITLE
fix(component): update c/proudctVariantSelector to show option label

### DIFF
--- a/force-app/main/default/lwc/productVariantSelector/productVariantSelector.js
+++ b/force-app/main/default/lwc/productVariantSelector/productVariantSelector.js
@@ -434,7 +434,7 @@ export default class ProductVariantSelector extends LightningElement {
             this._selectedAttributeIndex = +event.target.dataset.index;
 
             this._availableOptions = this.checkAndPopulateAvailableOptionsList
-                ? this._availableOptionsList && this._availableOptionsList[this._selectedAttributeIndex]
+                ? this._availableOptionsList?.[this._selectedAttributeIndex]
                 : getAvailableOptions(
                       this._selectedAttributeIndex,
                       this.currentlySelectedOptions,

--- a/force-app/main/default/lwc/productVariantSelector/productVariantSelectorUtils.js
+++ b/force-app/main/default/lwc/productVariantSelector/productVariantSelectorUtils.js
@@ -12,7 +12,7 @@
 const variantSupportedProductClasses = new Set(['Variation', 'VariationParent']);
 
 /**
- * Determines if option value at the selected attribute index is valid based
+ * Determines if the option value at the selected attribute index is valid based
  * on the provided valid variant and the currently selected options
  * @param {Array<string>} variant
  *  A valid variant to parse (e.g. ['Large', 'Yellow', 'Polyester'])
@@ -24,11 +24,11 @@ const variantSupportedProductClasses = new Set(['Variation', 'VariationParent'])
  *  True, if the option is valid
  */
 export function isOptionAtSelectedIndexValid(variant, selectedAttributeIndex, currentlySelectedOptions) {
-    return variant.every((variantOption, optionIndex) => {
+    return variant?.every((variantOption, optionIndex) => {
         const selectedOption = currentlySelectedOptions[optionIndex];
 
         return (
-            optionIndex === selectedAttributeIndex || selectedOption === variantOption || selectedOption.length === 0
+            optionIndex === selectedAttributeIndex || selectedOption === variantOption || selectedOption?.length === 0
         );
     });
 }
@@ -62,7 +62,7 @@ export function getAvailableOptions(selectedAttributeIndex, currentlySelectedOpt
             ?.filter((variant) =>
                 isOptionAtSelectedIndexValid(variant, selectedAttributeIndex, currentlySelectedOptions)
             )
-            .map((filteredOptions) => filteredOptions[selectedAttributeIndex])
+            ?.map((filteredOptions) => filteredOptions[selectedAttributeIndex])
     );
 }
 
@@ -144,7 +144,7 @@ export const transformSelectedOptions = (attributes, attributeInfo) => {
 };
 
 /**
- * Transform Variant Attributes list to a map
+ * Transform the Variant Attributes list to a map
  * @param {Array<JsonData>} [attributesToProductMappings] The product's variation attributes mapping
  * @returns {Map<string, {[key: string]: Array<string>}>} The consumable/normalized form of the variation attributes mapping
  * @example
@@ -193,7 +193,7 @@ export const transformVariantSelectionToProductIdMap = (attributesToProductMappi
     }, new Map());
 
 /**
- * Transform Variant Attributes list to a list of available variant options
+ * Transform the Variant Attributes list to a list of available variant options
  * @param {Array<JsonData>} [attributesToProductMappings] The product's variation attributes mapping
  * @returns {Array<Array<string>>} A list of available variant options
  * @example

--- a/force-app/main/default/lwc/productVariantSelector/productVariantSelectorUtils.js
+++ b/force-app/main/default/lwc/productVariantSelector/productVariantSelectorUtils.js
@@ -83,10 +83,13 @@ export const transformVariantOptions = (attributeInfo) => {
     return Object.values(attributeInfo || [])
         .filter(Boolean)
         .map((attribute) => {
-            const options = (attribute?.availableValues || []).map((value) => ({
-                label: value,
-                value: value,
-            }));
+            const options = (attribute?.availableValues || []).map((value) => {
+                const option = attribute?.options?.find((o) => o?.apiName === value);
+                return {
+                    label: option?.label,
+                    value: option?.apiName,
+                };
+            });
             return {
                 id: attribute?.fieldEnumOrId,
                 label: attribute?.label,


### PR DESCRIPTION
The `transformVariantOptions` method was returning the "apiName" because the `availableValues` found in the attribute info is use the apiNames. Updated to use those values to find the correct label/apiName pair found in the `options` array. This will keep the same value, but the value displayed in the drop down will use the label.

Also added some optional chain operators to `proudctVariantSelectorUtils` methods for better error protection.