### PR TITLE
ShopperAgent Gross Taxation Support

### DIFF
--- a/force-app/main/default/lwc/summaryDetails/__tests__/summaryDetails.test.js
+++ b/force-app/main/default/lwc/summaryDetails/__tests__/summaryDetails.test.js
@@ -522,6 +522,46 @@ describe('c-summary-details', () => {
             expect(hasSummaryValue(element, 'Taxes', 'TBD')).toBe(true);
         });
 
+        it('should hide taxes row when taxationMode is gross', async () => {
+            const dataWithGrossTaxation = { ...mockOrderData, taxationMode: 'gross' };
+            const element = await createComponent({ details: dataWithGrossTaxation });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+        });
+
+        it('should show taxes row when taxationMode is net', async () => {
+            const dataWithNetTaxation = { ...mockOrderData, taxationMode: 'net' };
+            const element = await createComponent({ details: dataWithNetTaxation });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(true);
+            expect(hasSummaryValue(element, 'Taxes', '$8.00')).toBe(true);
+        });
+
+        it('should show taxes row when taxationMode is undefined', async () => {
+            const dataWithUndefinedTaxation = { ...mockOrderData, taxationMode: undefined };
+            const element = await createComponent({ details: dataWithUndefinedTaxation });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(true);
+            expect(hasSummaryValue(element, 'Taxes', '$8.00')).toBe(true);
+        });
+
+        it('should hide taxes row in cart summary mode when taxationMode is gross', async () => {
+            const dataWithGrossTaxation = { ...mockCartData, taxationMode: 'gross' };
+            const element = await createComponent({
+                details: dataWithGrossTaxation,
+                isCartSummary: true,
+            });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+            // Other totals should still be visible
+            expect(hasSummaryLabel(element, 'Subtotal')).toBe(true);
+            expect(hasSummaryLabel(element, 'Shipping')).toBe(true);
+        });
+
         it('should display "TBD" for shipping when shippingCost is null or undefined', async () => {
             const dataWithTBDValues = { ...mockDataWithPromotionsAndDiscounts, shippingCost: undefined };
             const element = await createComponent({ details: dataWithTBDValues });
@@ -567,6 +607,28 @@ describe('c-summary-details', () => {
 
             expect(hasSummaryLabel(element, 'Promotions')).toBe(false);
             expect(hasSummaryLabel(element, 'Shipping Discount')).toBe(false);
+        });
+
+        it('should display summary structure without taxes when taxationMode is gross', async () => {
+            const dataGrossTaxation = {
+                ...mockDataWithPromotionsAndDiscounts,
+                taxationMode: 'gross',
+            };
+            const element = await createComponent({ details: dataGrossTaxation });
+            await expandComponent(element);
+
+            const summaryLabels = element.querySelectorAll('.summary-label');
+            const expectedOrder = ['Subtotal', 'Promotions', 'Shipping', 'Shipping Discount'];
+
+            expectedOrder.forEach((expectedLabel, index) => {
+                expect(summaryLabels[index].textContent).toBe(expectedLabel);
+            });
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+
+            // Total row should still be present
+            const totalRow = element.querySelector('.summary-row.total');
+            expect(totalRow).not.toBeNull();
         });
     });
 

--- a/force-app/main/default/lwc/summaryDetails/summaryDetails.html
+++ b/force-app/main/default/lwc/summaryDetails/summaryDetails.html
@@ -187,18 +187,20 @@
                         </div>
                     </template>
 
-                    <div class="summary-row slds-p-bottom_x-small">
-                        <span
-                            class="summary-label"
-                            id="taxes-label">
-                            {i18n.taxesLabel}
-                        </span>
-                        <span
-                            class="summary-value"
-                            aria-labelledby="taxes-label">
-                            {taxes}
-                        </span>
-                    </div>
+                    <template if:true={shouldShowTaxes}>
+                        <div class="summary-row slds-p-bottom_x-small">
+                            <span
+                                class="summary-label"
+                                id="taxes-label">
+                                {i18n.taxesLabel}
+                            </span>
+                            <span
+                                class="summary-value"
+                                aria-labelledby="taxes-label">
+                                {taxes}
+                            </span>
+                        </div>
+                    </template>
 
                     <div class="summary-row total">
                         <span

--- a/force-app/main/default/lwc/summaryDetails/summaryDetails.js
+++ b/force-app/main/default/lwc/summaryDetails/summaryDetails.js
@@ -348,6 +348,16 @@ export default class SummaryDetails extends LightningElement {
     }
 
     /**
+     * Indicates if taxes should be shown in the summary.
+     * When taxation mode is 'gross', taxes are included in the displayed prices
+     * and should not be shown as a separate line item.
+     * @returns {boolean} True if taxes should be displayed (i.e., taxation mode is not 'gross')
+     */
+    get shouldShowTaxes() {
+        return this.details?.taxationMode !== 'gross';
+    }
+
+    /**
      * Indicates if there is a coupon discount to display.
      * @returns {boolean} True if coupon discount amount is not null or undefined
      */


### PR DESCRIPTION
## ShopperAgent Gross Taxation Support

**Work Item:** W-22141386

### What
Hides the taxes row in the order/summary details when the taxation mode is **gross**. Under gross taxation, taxes are already included in the displayed prices, so showing a separate tax line item is redundant and misleading.

### How
- Adds a `shouldShowTaxes` getter on `summaryDetails` that returns `false` when `details.taxationMode === 'gross'`.
- Conditionally renders the tax line in `summaryDetails.html` based on that getter.

### Files changed
- `force-app/main/default/lwc/summaryDetails/summaryDetails.js`
- `force-app/main/default/lwc/summaryDetails/summaryDetails.html`
- `force-app/main/default/lwc/summaryDetails/__tests__/summaryDetails.test.js`

### Testing
- `summaryDetails` suite: 150 passing (includes new gross/net taxation cases)
- Full suite: 1093 passing

### Notes
Ported from internal PR #306 (commit `057cb1d`). Single-commit, scoped to the gross-taxation change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
