### PR TITLE
feat: gross taxation support - hide taxes row when taxationMode is gross

### DIFF
--- a/force-app/main/default/lwc/summaryDetails/__tests__/summaryDetails.test.js
+++ b/force-app/main/default/lwc/summaryDetails/__tests__/summaryDetails.test.js
@@ -568,6 +568,57 @@ describe('c-summary-details', () => {
             expect(hasSummaryLabel(element, 'Promotions')).toBe(false);
             expect(hasSummaryLabel(element, 'Shipping Discount')).toBe(false);
         });
+
+        it('should hide taxes row when taxationMode is gross', async () => {
+            const dataWithGrossTaxation = { ...mockOrderData, taxationMode: 'gross' };
+            const element = await createComponent({ details: dataWithGrossTaxation });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+        });
+
+        it('should show taxes row when taxationMode is net', async () => {
+            const dataWithNetTaxation = { ...mockOrderData, taxationMode: 'net' };
+            const element = await createComponent({ details: dataWithNetTaxation });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(true);
+        });
+
+        it('should show taxes row when taxationMode is undefined', async () => {
+            const element = await createComponent({ details: mockOrderData });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(true);
+        });
+
+        it('should hide taxes row in cart summary mode when taxationMode is gross', async () => {
+            const dataWithGrossTaxation = { ...mockCartData, taxationMode: 'gross' };
+            const element = await createComponent({ details: dataWithGrossTaxation, isCartSummary: true });
+            await expandComponent(element);
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+        });
+
+        it('should display summary structure without taxes when taxationMode is gross', async () => {
+            const dataWithGrossTaxation = {
+                ...mockDataWithPromotionsAndDiscounts,
+                taxationMode: 'gross',
+                shippingDiscount: 0,
+                promotionsDiscount: 0,
+            };
+            const element = await createComponent({ details: dataWithGrossTaxation });
+            await expandComponent(element);
+
+            const summaryLabels = element.querySelectorAll('.summary-label');
+            const expectedOrder = ['Subtotal', 'Shipping'];
+
+            expectedOrder.forEach((expectedLabel, index) => {
+                expect(summaryLabels[index].textContent).toBe(expectedLabel);
+            });
+
+            expect(hasSummaryLabel(element, 'Taxes')).toBe(false);
+        });
     });
 
     describe('Edge Cases', () => {

--- a/force-app/main/default/lwc/summaryDetails/summaryDetails.html
+++ b/force-app/main/default/lwc/summaryDetails/summaryDetails.html
@@ -187,18 +187,20 @@
                         </div>
                     </template>
 
-                    <div class="summary-row slds-p-bottom_x-small">
-                        <span
-                            class="summary-label"
-                            id="taxes-label">
-                            {i18n.taxesLabel}
-                        </span>
-                        <span
-                            class="summary-value"
-                            aria-labelledby="taxes-label">
-                            {taxes}
-                        </span>
-                    </div>
+                    <template if:true={shouldShowTaxes}>
+                        <div class="summary-row slds-p-bottom_x-small">
+                            <span
+                                class="summary-label"
+                                id="taxes-label">
+                                {i18n.taxesLabel}
+                            </span>
+                            <span
+                                class="summary-value"
+                                aria-labelledby="taxes-label">
+                                {taxes}
+                            </span>
+                        </div>
+                    </template>
 
                     <div class="summary-row total">
                         <span

--- a/force-app/main/default/lwc/summaryDetails/summaryDetails.js
+++ b/force-app/main/default/lwc/summaryDetails/summaryDetails.js
@@ -278,6 +278,14 @@ export default class SummaryDetails extends LightningElement {
     }
 
     /**
+     * True if taxes should be displayed (i.e., taxation mode is not 'gross').
+     * @returns {boolean}
+     */
+    get shouldShowTaxes() {
+        return this.details?.taxationMode !== 'gross';
+    }
+
+    /**
      * Indicates if there are any promotions to display.
      * @returns {boolean} True if promotions amount is not null or undefined
      */


### PR DESCRIPTION
## Summary
- Added `shouldShowTaxes` getter to `summaryDetails.js` that returns `false` when `taxationMode` is `'gross'`
- Wrapped the taxes row in `summaryDetails.html` with `<template if:true={shouldShowTaxes}>` to conditionally hide it
- Added 5 new test cases covering gross/net/undefined taxation modes and cart summary mode behavior

## Context
In gross taxation mode, taxes are already included in the displayed prices, so the separate taxes line item should not be shown to users.

## Test plan
- [ ] Taxes row is hidden when `details.taxationMode === 'gross'`
- [ ] Taxes row is shown when `details.taxationMode === 'net'`
- [ ] Taxes row is shown when `taxationMode` is `undefined` (default behavior unchanged)
- [ ] Taxes row is hidden in cart summary mode when `taxationMode === 'gross'`
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)